### PR TITLE
Improve syntax: 'object' is not required anymore

### DIFF
--- a/caseenum/README.md
+++ b/caseenum/README.md
@@ -41,6 +41,31 @@ To enable the macro paradise plugin (for the @enum annotation), also add
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0-M5" cross CrossVersion.full)
 ```
 
+## Supported syntaxes
+The `object` keyword is optional in the case declarations. So this:
+
+```scala
+@enum trait Planet {
+  object Earth
+  object Venus
+  object Mercury
+}
+```
+
+can also be written more concisely as
+
+```scala
+@enum trait Planet {
+  Earth
+  Venus
+  Mercury
+}
+```
+
+The first version (slightly more verbose) has a more "scalish feel", and allows you maintain your code closer to the result of the macro expansion.
+
+The second version (more compact) looks a bit less like scala, but it allows you to strip away another bit of boilerplate.
+
 ## Convention and marker trait
 
 The `@enum` annotation builds enumerations that follow the library's convention for how ADT-based enums should be encoded. However, usage of the macro annotation can be avoided by manually writing out the ADT. Here's an example that serves as an informal definition of the convention.

--- a/caseenum/src/main/scala/macro.scala
+++ b/caseenum/src/main/scala/macro.scala
@@ -118,13 +118,13 @@ object IndexedEnumMacro {
       }
       val typeAliasTree :: memberTrees = body
       val members = memberTrees.map {
-        case Apply(Ident(memberName: TermName), List(statement)) =>
+        case Apply(Ident(memberName: TermName), List(expression)) =>
           q"""case object $memberName extends $enumName {
-                val index = $statement
+                val index = $expression
               }"""
-        case q"object $memberName { $statement  }" =>
+        case q"object $memberName { $expression  }" =>
           q"""case object $memberName extends $enumName {
-                val index = $statement
+                val index = $expression
               }"""
         case _ =>
           c.abort(c.enclosingPosition, "Enum members should be plain objects")

--- a/caseenum/src/main/scala/macro.scala
+++ b/caseenum/src/main/scala/macro.scala
@@ -49,7 +49,9 @@ object EnumMacro {
           c.abort(c.enclosingPosition, "Annotation is only supported on objects")
       }
       val members = body.map {
-        case q"object $memberName { ..$more }" =>
+        case Ident(memberName: TermName) =>
+          q"case object $memberName extends $enumName"
+        case q"object $memberName { ..$more  }" =>
           q"case object $memberName extends $enumName"
         case _ =>
           c.abort(c.enclosingPosition, "Enum members should be plain objects")
@@ -116,7 +118,11 @@ object IndexedEnumMacro {
       }
       val typeAliasTree :: memberTrees = body
       val members = memberTrees.map {
-        case q"object $memberName { $statement }" =>
+        case Apply(Ident(memberName: TermName), List(statement)) =>
+          q"""case object $memberName extends $enumName {
+                val index = $statement
+              }"""
+        case q"object $memberName { $statement  }" =>
           q"""case object $memberName extends $enumName {
                 val index = $statement
               }"""

--- a/caseenum/src/test/scala/CaseEnumMacroSpec.scala
+++ b/caseenum/src/test/scala/CaseEnumMacroSpec.scala
@@ -4,9 +4,14 @@ import org.scalatest.{ Matchers, WordSpec }
 
 class CaseEnumMacroSpec extends WordSpec with Matchers {
   @enum trait Planet {
-    object Mercury
-    object Venus
-    object Earth
+    Mercury
+    Venus
+    Earth
+  }
+
+  @enum trait Beer {
+    object Lager
+    object Ale
   }
 
   "@enum annotation" should {
@@ -17,6 +22,14 @@ class CaseEnumMacroSpec extends WordSpec with Matchers {
       Planet.Mercury should not be a [Planet.Earth.type]
       Planet.Earth shouldBe Planet.Earth
     }
+
+    "produce a valid CaseEnum-style ADT (alternative syntax)" in {
+      Beer.Lager shouldBe a[Product]
+      Beer.Lager shouldBe a[Serializable]
+      Beer.Lager shouldBe a[Beer]
+      Beer.Ale should not be a [Beer.Lager.type]
+      Beer.Lager shouldBe Beer.Lager
+    }
   }
 
 }
@@ -24,9 +37,15 @@ class CaseEnumMacroSpec extends WordSpec with Matchers {
 class IndexedCaseEnumMacroSpec extends WordSpec with Matchers {
   @indexedEnum trait Planet {
     type Index = Int
-    object Mercury { 1 }
-    object Venus   { 2 }
-    object Earth   { 3 }
+    Mercury { 1 }
+    Venus   { 2 }
+    Earth   { 3 }
+  }
+
+  @indexedEnum trait Beer {
+    type Index = Int
+    Lager { 1 }
+    Ale { 2 }
   }
 
   "@indexedEnum annotation" should {
@@ -38,6 +57,16 @@ class IndexedCaseEnumMacroSpec extends WordSpec with Matchers {
       Planet.Mercury should not be a [Planet.Earth.type]
       Planet.Earth shouldBe Planet.Earth
       Planet.Earth.index shouldBe 3
+    }
+
+    "produce a valid IndexedCaseEnum-style ADT (alternative syntax)" in {
+      val typecheck: Int = 2: Planet#Index
+      Beer.Lager shouldBe a[Product]
+      Beer.Lager shouldBe a[Serializable]
+      Beer.Lager shouldBe a[Beer]
+      Beer.Ale should not be a [Beer.Lager.type]
+      Beer.Lager shouldBe Beer.Lager
+      Beer.Ale.index shouldBe 2
     }
   }
 


### PR DESCRIPTION
In short, instead of this

``` scala
@enum trait Planet {
  object Mercury
  object Venus
  object Earth
}
```

we can do this

``` scala
@enum trait Planet {
  Mercury
  Venus
  Earth
}
```

both syntaxes are allowed.
